### PR TITLE
Day of the month tap

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -18,7 +18,7 @@
         "chalk"
     ],
     "uuid": "12eef850-a261-4c3f-a06c-b939e62f49c5",
-    "versionLabel": "1.0",
+    "versionLabel": "1.1",
     "watchapp": {
         "watchface": true
     }


### PR DESCRIPTION
The day of the month appears after a significant tap or shake of the watch. The empty half side of the screen is choosen according to the minutes hand position.
The day disappears after a minute is elapsed.
